### PR TITLE
Fix PreparedStatement metadata query wrapping

### DIFF
--- a/src/main/kotlin/WsdlPreparedStatement.kt
+++ b/src/main/kotlin/WsdlPreparedStatement.kt
@@ -216,8 +216,12 @@ class WsdlPreparedStatement(
         val finalSql = buildSql()
         logger.info("Retrieving metadata for prepared SQL: {}", finalSql)
 
-        // Fetch zero rows to obtain metadata without data transfer
-        val metaQuery = "$finalSql WHERE 1=0"
+        // Fetch zero rows to obtain metadata without transferring data.
+        // Wrap the original query to avoid breaking existing ORDER BY or
+        // pagination clauses when appending the WHERE predicate.
+        val metaQuery = "SELECT * FROM (" +
+            finalSql.trim().trimEnd(';') +
+            ") WHERE 1=0"
         super.executeQuery(metaQuery).use { rs ->
             val md = rs.metaData
             cachedMeta = md


### PR DESCRIPTION
## Summary
- fix building of metadata query in WsdlPreparedStatement
  to wrap original SQL when appending `WHERE 1=0`

## Testing
- `gradle test` *(fails: Plugin not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685150eed06c832ca314cee34e93893e