### PR TITLE
Add paginated metadata fetching

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     implementation("org.duckdb:duckdb_jdbc:+")
     // A simple SLF4J binding (choose one that fits your needs; here we use slf4j-simple)
     runtimeOnly("org.slf4j:slf4j-simple:+")
+
+    testImplementation(kotlin("test"))
+    testImplementation("io.mockk:mockk:+")
 }
 
 tasks.test {

--- a/src/test/kotlin/my/jdbc/wsdl_driver/PaginationHelperTest.kt
+++ b/src/test/kotlin/my/jdbc/wsdl_driver/PaginationHelperTest.kt
@@ -1,0 +1,47 @@
+package my.jdbc.wsdl_driver
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PaginationHelperTest {
+    @Test
+    fun `fetchAllPages accumulates all rows`() {
+        mockkStatic("my.jdbc.wsdl_driver.UtilsKt")
+        val page1 = "<ROWSET><ROW><A>1</A></ROW></ROWSET>"
+        val page2 = "<ROWSET><ROW><A>2</A></ROW></ROWSET>"
+        val empty = "<ROWSET/>"
+        every { sendSqlViaWsdl(any(), any(), any(), any(), any()) } returnsMany listOf(page1, page2, empty)
+
+        val rows = fetchAllPages(
+            wsdlEndpoint = "http://x",
+            sql = "select * from dual",
+            username = "u",
+            password = "p",
+            reportPath = "/r",
+            fetchSize = 1,
+            parsePage = { xml ->
+                val doc = parseXml(xml)
+                val list = doc.getElementsByTagName("ROW")
+                val res = mutableListOf<Map<String,String>>()
+                for (i in 0 until list.length) {
+                    val node = list.item(i)
+                    val map = mutableMapOf<String,String>()
+                    val children = node.childNodes
+                    for (j in 0 until children.length) {
+                        val child = children.item(j)
+                        if (child.nodeType == org.w3c.dom.Node.ELEMENT_NODE) {
+                            map[child.nodeName.lowercase()] = child.textContent.trim()
+                        }
+                    }
+                    res.add(map)
+                }
+                res
+            }
+        )
+        assertEquals(listOf("1","2"), rows.map { it["a"] })
+        unmockkStatic("my.jdbc.wsdl_driver.UtilsKt")
+    }
+}

--- a/src/test/kotlin/my/jdbc/wsdl_driver/WsdlDatabaseMetaDataPaginationTest.kt
+++ b/src/test/kotlin/my/jdbc/wsdl_driver/WsdlDatabaseMetaDataPaginationTest.kt
@@ -1,0 +1,41 @@
+package my.jdbc.wsdl_driver
+
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WsdlDatabaseMetaDataPaginationTest {
+    @BeforeTest
+    fun setup() {
+        mockkStatic("my.jdbc.wsdl_driver.UtilsKt")
+        WsdlDatabaseMetaData.METADATA_FETCH_SIZE = 1
+    }
+
+    @AfterTest
+    fun teardown() {
+        unmockkStatic("my.jdbc.wsdl_driver.UtilsKt")
+        WsdlDatabaseMetaData.METADATA_FETCH_SIZE = 1000
+        LocalMetadataCache.clearAllCache()
+    }
+
+    @Test
+    fun `getTables fetches multiple pages`() {
+        val page1 = "<ROWSET><ROW><TABLE_NAME>T1</TABLE_NAME><TABLE_TYPE>TABLE</TABLE_TYPE></ROW></ROWSET>"
+        val page2 = "<ROWSET><ROW><TABLE_NAME>T2</TABLE_NAME><TABLE_TYPE>TABLE</TABLE_TYPE></ROW></ROWSET>"
+        val empty = "<ROWSET/>"
+        every { sendSqlViaWsdl(any(), any(), any(), any(), any()) } returnsMany listOf(page1, page2, empty)
+
+        val conn = WsdlConnection("http://x","u","p","/r")
+        val meta = WsdlDatabaseMetaData(conn)
+        val rs = meta.getTables(null, null, null, arrayOf("TABLE"))
+        val names = mutableListOf<String>()
+        while (rs.next()) {
+            names.add(rs.getString("table_name"))
+        }
+        assertEquals(listOf("T1","T2"), names)
+    }
+}


### PR DESCRIPTION
## Summary
- add `fetchAllPages` helper for paged SOAP SQL calls
- paginate table, column, primary key and index info queries
- expose metadata fetch size
- add unit tests for pagination logic

## Testing
- `gradle test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688d62743f70832c953e31ab0d9e3814